### PR TITLE
Remove the need to explicitly declare opts in user's module

### DIFF
--- a/lib/tabula.ex
+++ b/lib/tabula.ex
@@ -30,14 +30,12 @@ defmodule Tabula do
 
   defmacro __using__(opts) do
     quote do
-      @opts unquote(opts)
-      def opts, do: @opts
       def print_table(rows) do
-        unquote(__MODULE__).print_table(rows, opts)
+        unquote(__MODULE__).print_table(rows, unquote(opts))
       end
       def print_table(rows, override_opts) do
         unquote(__MODULE__).print_table(
-          rows, Keyword.merge(opts, override_opts)
+          rows, Keyword.merge(unquote(opts), override_opts)
         ) end
     end
   end


### PR DESCRIPTION
As in title. Simple `unquote` suffices here and we avoid messing with user's module. Should close #3 
