### PR TITLE
Support keyword lists

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -35,8 +35,8 @@ defmodule Tabula.Mixfile do
   #
   # Type `mix help deps` for more examples and options
   defp deps do
-    [{:earmark, "~> 0.1", only: :dev},
-      {:ex_doc, "~> 0.10", only: :dev}]
+    [{:earmark, "~> 0.2.1", only: :dev},
+      {:ex_doc, "~> 0.12.0", only: :dev}]
   end
 
   defp package do

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,2 @@
-%{"earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.12.0", "b774aabfede4af31c0301aece12371cbd25995a21bb3d71d66f5c2fe074c603f", [:mix], [{:earmark, "~> 0.2", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"}}
+%{"earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], []},
+  "ex_doc": {:hex, :ex_doc, "0.12.0", "b774aabfede4af31c0301aece12371cbd25995a21bb3d71d66f5c2fe074c603f", [:mix], [{:earmark, "~> 0.2", [hex: :earmark, optional: false]}]}}

--- a/test/tabula_test.exs
+++ b/test/tabula_test.exs
@@ -145,4 +145,19 @@ defmodule TabulaTest do
     assert table == expect
   end
 
+  test "Support keyword lists and preserve ordering of columns" do
+    rows = [
+      [name: "ecto", point: %Point{x: 0, y: 0}, version: Version.parse!("2.0.4")],
+      [name: "phoenix", point: %Point{x: 1, y: 0}, version: Version.parse!("1.2.0")]
+    ]
+    table = Tabula.render_table(rows)
+
+    expect = """
+    :name   | :point                        | :version
+    --------+-------------------------------+---------
+    ecto    | %TabulaTest.Point{x: 0, y: 0} | 2.0.4   
+    phoenix | %TabulaTest.Point{x: 1, y: 0} | 1.2.0   
+    """
+    assert table == expect
+  end
 end


### PR DESCRIPTION
The solutions I end up implementing could be largely improved. A general refactoring regarding the options passed down to the various utility functions could have be done to improve the suggested solution. However it would have been to disruptive IMHO for this PR. 

These are the main points addressed by this PR:

- Add module attribute `@access_functions` to handle the functions required to manage both maps and keyword lists.
- Add proper setup of access functions at table rendering time, i.e. `set_access_functions`.
- Add usage of access functions in `max_widths`, `extract_cols` and `values`.
- Update dependencies to get rid of warnings.

For anything (clarifications, changes requests, etc.) I remain obviously at disposal.

Cheers! 😄