### PR TITLE
Fix structs support

### DIFF
--- a/lib/tabula.ex
+++ b/lib/tabula.ex
@@ -47,6 +47,7 @@ defmodule Tabula do
   end
 
   defprotocol Row do
+    @fallback_to_any true
     def get(row, col, default \\ nil)
     def keys(row)
   end
@@ -59,6 +60,11 @@ defmodule Tabula do
   defimpl Row, for: List do
     def get(row, col, default \\ nil), do: row |> Keyword.get(col, default)
     def keys(row), do: row |> Keyword.keys
+  end
+
+  defimpl Row, for: Any do
+    def get(%{__struct__: _} = row, col, default \\ nil), do: row |> Map.get(col, default)
+    def keys(row), do: row |> Map.from_struct |> Map.keys
   end
 
   def print_table(rows, opts \\ []) do

--- a/test/tabula_test.exs
+++ b/test/tabula_test.exs
@@ -160,4 +160,17 @@ defmodule TabulaTest do
     """
     assert table == expect
   end
+
+  test "Prints the expected results for collections of Structs" do
+    rows = [%Point{x: 0, y: 0}, %Point{x: 1, y: 0}]
+    table = Tabula.render_table(rows)
+
+    expect = """
+    :x | :y
+    ---+---
+     0 |  0
+     1 |  0
+    """
+    assert table == expect
+  end
 end

--- a/test/tabula_test.exs
+++ b/test/tabula_test.exs
@@ -173,4 +173,15 @@ defmodule TabulaTest do
     """
     assert table == expect
   end
+
+  test "Tabula.Row.get" do
+    assert Tabula.Row.get(%{x: 0, y: 0}, :x) == 0
+    assert Tabula.Row.get([x: 0, y: 0], :x) == 0
+  end
+
+  test "Tabula.Row.keys" do
+    assert Tabula.Row.keys([x: 0, y: 0]) == ~w(x y)a
+    assert Tabula.Row.keys(%{x: 0, y: 0}) == ~w(x y)a
+    assert Tabula.Row.keys(%Point{x: 0, y: 0}) == ~w(x y)a
+  end
 end


### PR DESCRIPTION
This PR address the regression introduced by the PR #15 and reported by @wojtekmach [here](https://github.com/aerosol/Tabula/pull/15#issuecomment-297058113).

The solution proposed rely on the `Any` protocol implementation and on the `@fallback_to_any true` option.

An alternative solution can be, as stated by @wojtekmach once again [here](https://github.com/aerosol/Tabula/pull/15#issuecomment-297058113), to explicitly check for the protocol implementation.