### PR TITLE
Implement outer borders for tables

### DIFF
--- a/lib/tabula.ex
+++ b/lib/tabula.ex
@@ -18,16 +18,24 @@ defmodule Tabula do
 
   @sheets \
   org_mode: [
-    heading:        " | ",
-    heading_border: "-+-",
-    row:            " | ",
-    spacer:         "-"
+    heading:                    " | ",
+    heading_border:             "-+-",
+    heading_left_outer_border:  "|-",
+    heading_right_outer_border: "-|",
+    left_outer_border:          "| ",
+    right_outer_border:         " |",
+    row:                        " | ",
+    spacer:                     "-"
   ],
   github_md: [
-    heading:        " | ",
-    heading_border: " | ",
-    row:            " | ",
-    spacer:         "-"
+    heading:                    " | ",
+    heading_border:             " | ",
+    heading_left_outer_border:  "| ",
+    heading_right_outer_border: " |",
+    left_outer_border:          "| ",
+    right_outer_border:         " |",
+    row:                        " | ",
+    spacer:                     "-"
   ]
 
   @default_sheet :org_mode
@@ -132,12 +140,16 @@ defmodule Tabula do
 
   defp render_row(cells, style_element, formatters, opts) do
     separator = style(style_element, opts)
+    {left_outer_border, right_outer_border} =
+      outer_border_style(style_element, opts)
 
-    cells
-    |> zip(formatters)
-    |> map(fn {k, f} -> f.(k) end)
-    |> intersperse(separator)
-    |> concat(@newline)
+    row =
+      cells
+      |> zip(formatters)
+      |> map(fn {k, f} -> f.(k) end)
+      |> intersperse(separator)
+
+    concat([left_outer_border, row, right_outer_border], @newline)
   end
 
   defp render_cell(v) when is_binary(v), do: v
@@ -185,6 +197,16 @@ defmodule Tabula do
     map(cols, fn (@index) -> index + 1
                  (col)    -> Row.get(row, col)
               end)
+  end
+
+  defp outer_border_style(:heading_border, opts) do
+    {style(:heading_left_outer_border, opts),
+     style(:heading_right_outer_border, opts)}
+  end
+
+  defp outer_border_style(style, opts) when style in [:heading, :row] do
+    {style(:left_outer_border, opts),
+     style(:right_outer_border, opts)}
   end
 
   defp style(style, opts) do

--- a/test/tabula_test.exs
+++ b/test/tabula_test.exs
@@ -24,10 +24,10 @@ defmodule TabulaTest do
   test "Special column '#' can be provided to enumerate rows" do
     table = Tabula.render_table(@rows, only: ["#"|@cols])
     expect = """
-      # | name    | age | city    
-    ----+---------+-----+---------
-      1 | Adam    |  32 | Warsaw  
-      2 | Yolanda |  28 | New York
+    |   # | name    | age | city     |
+    |-----+---------+-----+----------|
+    |   1 | Adam    |  32 | Warsaw   |
+    |   2 | Yolanda |  28 | New York |
     """
     assert table == expect
   end
@@ -37,10 +37,10 @@ defmodule TabulaTest do
       Tabula.print_table @rows
     end
     expect = """
-    age | city     | name   
-    ----+----------+--------
-     32 | Warsaw   | Adam   
-     28 | New York | Yolanda
+    | age | city     | name    |
+    |-----+----------+---------|
+    |  32 | Warsaw   | Adam    |
+    |  28 | New York | Yolanda |
 
     """
     assert capture_io(table) == expect
@@ -49,10 +49,10 @@ defmodule TabulaTest do
   test "Github Markdown style can be applied" do
     table = Tabula.render_table(@rows, only: Enum.sort(@cols), style: :github_md)
     expect = """
-    age | city     | name   
-    --- | -------- | -------
-     32 | Warsaw   | Adam   
-     28 | New York | Yolanda
+    | age | city     | name    |
+    | --- | -------- | ------- |
+    |  32 | Warsaw   | Adam    |
+    |  28 | New York | Yolanda |
     """
     assert table == expect
   end
@@ -60,10 +60,10 @@ defmodule TabulaTest do
   test "Columns not found are represented by `nil`" do
     table = Tabula.render_table(@rows, only: ["phone", "email"])
     expect = """
-    phone | email
-    ------+------
-    nil   | nil  
-    nil   | nil  
+    | phone | email |
+    |-------+-------|
+    | nil   | nil   |
+    | nil   | nil   |
     """
     assert table == expect
   end
@@ -101,21 +101,21 @@ defmodule TabulaTest do
     end
 
     e1 = """
-    cruel | hello
-    ----- | -----
-    true  | world
+    | cruel | hello |
+    | ----- | ----- |
+    | true  | world |
     """
 
     e2 = """
-    cruel
-    -----
-    true 
+    | cruel |
+    | ----- |
+    | true  |
     """
 
     e3 = """
-      # | cruel
-    ----+------
-      1 | true 
+    |   # | cruel |
+    |-----+-------|
+    |   1 | true  |
     """
 
     assert Bar.t1 == e1
@@ -137,10 +137,10 @@ defmodule TabulaTest do
     table = Tabula.render_table(rows)
 
     expect = """
-    :name   | :point                        | :version
-    --------+-------------------------------+---------
-    ecto    | %TabulaTest.Point{x: 0, y: 0} | 2.0.4   
-    phoenix | %TabulaTest.Point{x: 1, y: 0} | 1.2.0   
+    | :name   | :point                        | :version |
+    |---------+-------------------------------+----------|
+    | ecto    | %TabulaTest.Point{x: 0, y: 0} | 2.0.4    |
+    | phoenix | %TabulaTest.Point{x: 1, y: 0} | 1.2.0    |
     """
     assert table == expect
   end
@@ -153,10 +153,10 @@ defmodule TabulaTest do
     table = Tabula.render_table(rows)
 
     expect = """
-    :name   | :point                        | :version
-    --------+-------------------------------+---------
-    ecto    | %TabulaTest.Point{x: 0, y: 0} | 2.0.4   
-    phoenix | %TabulaTest.Point{x: 1, y: 0} | 1.2.0   
+    | :name   | :point                        | :version |
+    |---------+-------------------------------+----------|
+    | ecto    | %TabulaTest.Point{x: 0, y: 0} | 2.0.4    |
+    | phoenix | %TabulaTest.Point{x: 1, y: 0} | 1.2.0    |
     """
     assert table == expect
   end
@@ -166,10 +166,10 @@ defmodule TabulaTest do
     table = Tabula.render_table(rows)
 
     expect = """
-    :x | :y
-    ---+---
-     0 |  0
-     1 |  0
+    | :x | :y |
+    |----+----|
+    |  0 |  0 |
+    |  1 |  0 |
     """
     assert table == expect
   end


### PR DESCRIPTION
In some specific cases, markdown renderer used by Github fails to render tables generated by Tabula. It turns out adding outer borders on the edges of the table fixes this. That also seems to be the officially supported syntax, per https://github.github.com/gfm/#tables-extension-. Same respective change was done for org mode styled tables, which is in agreement with the respective spec too, as outlined in https://orgmode.org/worg/org-tutorials/tables.html.
